### PR TITLE
Self-contained-coordinator consumer group fixes and datasink helper setnames now being set to redistimeseries

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1119,7 +1119,7 @@ hiredis = ["hiredis (>=0.1.3)"]
 
 [[package]]
 name = "redisbench-admin"
-version = "0.4.14"
+version = "0.4.15"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 category = "main"
 optional = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redis-benchmarks-specification"
-version = "0.1.6"
+version = "0.1.7"
 description = "The Redis benchmarks specification describes the cross-language/tools requirements and expectations to foster performance and observability standards around redis related technologies. Members from both industry and academia, including organizations and individuals are encouraged to contribute."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>"]
 readme = "Readme.md"
@@ -16,7 +16,7 @@ argparse = "^1.4.0"
 Flask-HTTPAuth = "^4.4.0"
 PyYAML = "^5.4.1"
 docker = "^4.4.4"
-redisbench-admin = "^0.4.14"
+redisbench-admin = "^0.4.15"
 psutil = "^5.8.0"
 tox-docker = "^3.0.0"
 


### PR DESCRIPTION
- [fix] consumer groups for self-contained-coordinator should be broken by running_platform; Fixes #28 
- [fix] SETS for testcases:build_variants, platforms, testcases:metric_context_path are missing; Fixes #27 